### PR TITLE
Secure docker-compose: enable Mongo auth, drop full repo bind-mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,22 @@
 version: "3.9"
 
+# Before running, define these in a local .env file (never commit it):
+#   MONGO_ROOT_USERNAME=admin
+#   MONGO_ROOT_PASSWORD=<a strong, unique password>
+# Compose reads .env automatically and injects the values below.
+
 services:
   mongodb:
     image: mongo:6
     restart: unless-stopped
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGO_ROOT_USERNAME:?set MONGO_ROOT_USERNAME in .env}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:?set MONGO_ROOT_PASSWORD in .env}
+    # Bind to loopback only so the database is not reachable from the wider
+    # network. The app talks to it over the internal compose network regardless,
+    # so you can drop this mapping entirely if you don't need host access.
     ports:
-      - "27017:27017"
+      - "127.0.0.1:27017:27017"
     volumes:
       - mongo_data:/data/db
 
@@ -15,13 +26,22 @@ services:
     env_file:
       - .env
     environment:
-      - MONGO_URI=mongodb://mongodb:27017
+      # Overrides MONGO_URI from .env; connects with the credentials above.
+      - MONGO_URI=mongodb://${MONGO_ROOT_USERNAME}:${MONGO_ROOT_PASSWORD}@mongodb:27017/?authSource=admin
     ports:
       - "8000:8000"
     depends_on:
       - mongodb
-    volumes:
-      - ./:/app
+    # No bind-mount: the image is built with `COPY . ./` (see Dockerfile), so the
+    # container runs a self-contained, reproducible copy of the code and never
+    # exposes host-only files like .env or .git.
+    #
+    # For local live-reload during development, create a docker-compose.override.yml
+    # that mounts only the source, e.g.:
+    #   services:
+    #     app:
+    #       volumes:
+    #         - ./app:/app/app
 
 volumes:
   mongo_data:


### PR DESCRIPTION
## What this fixes

Resolves #20 — both problems in `docker-compose.yml`.

### 1. MongoDB now requires authentication
- Added `MONGO_INITDB_ROOT_USERNAME` / `MONGO_INITDB_ROOT_PASSWORD`, sourced from `.env` (never committed).
- The app connects with an authenticated URI: `mongodb://<user>:<pass>@mongodb:27017/?authSource=admin`.
- Published port bound to `127.0.0.1:27017` so the database is not reachable from the wider network. (It can be dropped entirely — the app reaches Mongo over the internal compose network either way.)

### 2. Removed the full-repo bind-mount
- Deleted `./:/app`, which mounted the entire working tree (`.env`, `.git`, caches) into the container and caused non-reproducible builds.
- The image already ships the code via `COPY . ./` in the Dockerfile, so nothing is lost.
- Documented a dev-only `docker-compose.override.yml` snippet for live-reload that mounts only `./app`.

## Setup note
Add to your local `.env`:
```
MONGO_ROOT_USERNAME=admin
MONGO_ROOT_PASSWORD=<a strong, unique password>
```

## Verification
`docker compose config` resolves cleanly:
- `MONGO_URI` → `mongodb://admin:***@mongodb:27017/?authSource=admin`
- mongodb port → `host_ip: 127.0.0.1`
- app service has no bind-mount